### PR TITLE
fix(internal-store): resolve server/client boundary error in QRCodeDownload

### DIFF
--- a/src/components/common/QRCodeDownload.tsx
+++ b/src/components/common/QRCodeDownload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { QRCodeSVG } from 'qrcode.react';
 import { Download } from 'lucide-react';
 import { trackDownload } from '@/hooks/useTrackInternalStore';


### PR DESCRIPTION
## Summary
- Add 'use client' directive to QRCodeDownload component to fix server/client boundary error
- Resolves: "Attempted to call trackDownload() from the server but trackDownload is on the client"

## Test plan
- [x] Build passes successfully
- [ ] Verify /internal-store route loads without errors
- [ ] Test APK download tracking functionality

🤖 Generated with [Claude Code](https://claude.ai/code)